### PR TITLE
feat: defaults to plaintext / map languages to be rendered as another

### DIFF
--- a/apps/storybook/stories/internal/orama-chat-assistent-message.stories.tsx
+++ b/apps/storybook/stories/internal/orama-chat-assistent-message.stories.tsx
@@ -52,10 +52,20 @@ Ready to start writing?  Either start changing stuff on the left or
 [Marked]: https://github.com/markedjs/marked/
 [Markdown]: http://daringfireball.net/projects/markdown/
 
-\`\`\`javascript
-function helloWorld() {
-  console.log('Hello World!')
-}
+\`\`\`html
+<html>
+  <head>
+    <title>Hello World</title>
+  </head>
+  <body>
+  <script>
+    function helloWorld() {
+      console.log('Hello World!')
+    }
+  </script>
+    <h1>Hello World</h1>
+  </body>
+</html>
 \`\`\`
 
 \`\`\`javascript
@@ -83,6 +93,15 @@ for(int i = 0; i < 10; i++) {
 \`\`\`
 
 \`\`\`java
+class HelloWorld {
+  public static void main(String[] args) {
+    System.out.println("Hello World!");
+  }
+}
+\`\`\`
+
+\`\`\`unsuported
+<h1>Hello World</h1>
 class HelloWorld {
   public static void main(String[] args) {
     System.out.println("Hello World!");


### PR DESCRIPTION
For some reasons there are some languages that should be rendered as another. HMTL is one of these examples. It should be rendered as XML. I'm unsure about the reason. There probable be another languages that we should take the same approach, but I do not know them yet.

For now I generated a map for these languages.

Also, if the language is unknown, we're highlighting them as plaintext. This way be can scape tokens like:
`<h1>` which would be rendered as a h1 tag instead of a code.

I've also added the broken cases to the storybook so we can keep an eye on it :)