### PR TITLE
fix wrong colors for list item

### DIFF
--- a/packages/ui-stencil/src/components/internal/orama-search-results/orama-search-results.scss
+++ b/packages/ui-stencil/src/components/internal/orama-search-results/orama-search-results.scss
@@ -45,7 +45,7 @@
   align-items: center;
   padding: var(--spacing-m, $spacing-m);
   border-radius: var(--radius-s, $radius-s);
-  background-color: var(--background-color-primary, background-color('primary'));
+  background-color: var(--background-color-secondary, background-color('secondary'));
   border: 1px solid transparent;
   text-align: left;
   width: 100%;
@@ -55,7 +55,7 @@
 
   @media (hover: hover) {
     &:hover {
-      background-color: var(--background-color-secondary, background-color('secondary'));
+      background-color: var(--background-color-tertiary, background-color('tertiary'));
     }
   }
 


### PR DESCRIPTION
# Issue
https://linear.app/oramasearch/issue/ORM-1784/[bug]-default-ui-colors

Before:
<img width="646" alt="image" src="https://github.com/user-attachments/assets/14c41a76-ffd0-467a-8e64-fae04b3e8131">


After:
<img width="618" alt="image" src="https://github.com/user-attachments/assets/ee8ca55f-8a01-44e2-baf5-26200d246310">
